### PR TITLE
Responsive charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ altair2fasthtml(chart, vega_options={"renderer":"svg"})
 altair2fasthtml(chart, vega_options={"actions":True})
 ```
 
+### Responsive width
+
+As shown in the sample code above, you can control the width and height of your chart using `alt.Chart(...).properties(width, height)`. Additionally, if you would like the chart to dynamically take up the full width of its parent container, you can pass `full_width=True` to `altair2fasthtml` like so:
+
+```python
+# Renders a chart taking up the full width of the parent container
+altair2fasthtml(chart, full_width=True)
+```
+
 ## Roadmap
 
 This repository is originally meant to be simple helper, but if there are more advanced use-cases to consider I will gladly consider them. Please start a conversation by opening up an issue before starting a PR though.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ def generate_chart():
 This will return a `Div` that contains your rendered altair chart.
 
 ### Custom Vega options
+
 Under the hood, `altair2fasthtml` makes a call to the `vegaEmbed` javascript library. The `vegaEmbed` javascript library accepts [various options](https://github.com/vega/vega-embed?tab=readme-ov-file#options) that alter the rendered chart. You can optionally pass custom Vega options like so:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ def generate_chart():
 
 This will return a `Div` that contains your rendered altair chart.
 
+### Custom Vega options
+Under the hood, `altair2fasthtml` makes a call to the `vegaEmbed` javascript library. The `vegaEmbed` javascript library accepts [various options](https://github.com/vega/vega-embed?tab=readme-ov-file#options) that alter the rendered chart. You can optionally pass custom Vega options like so:
+
+```python
+# To render your chart as a svg instead of the default canvas element
+altair2fasthtml(chart, vega_options={"renderer":"svg"})
+
+# To render your chart with action links turned on (by default action links are disabled) 
+altair2fasthtml(chart, vega_options={"actions":True})
+```
+
 ## Roadmap
 
 This repository is originally meant to be simple helper, but if there are more advanced use-cases to consider I will gladly consider them. Please start a conversation by opening up an issue before starting a PR though.

--- a/fh_altair/__init__.py
+++ b/fh_altair/__init__.py
@@ -19,6 +19,22 @@ def altair2fasthml(chart):
 
 
 def altair2fasthtml(chart, vega_options={"actions": False}):
+    """Convert an Altair chart to a FastHTML FT component
+
+    Parameters
+    ----------
+    chart : altair.Chart
+        An Altair chart
+    vega_options : dict, optional
+        Options dictionary passed to the vegaEmbed function, by default {"actions": False}
+        which hides the Vega action menu.
+
+    Returns
+    -------
+    fastcore.xml.FT
+        A FastHTML FT component containing both the target div and embedding script
+
+    """
     jsonstr = chart.to_json()
     chart_id = f"uniq-{uuid4()}"
     return Div(

--- a/fh_altair/__init__.py
+++ b/fh_altair/__init__.py
@@ -1,17 +1,19 @@
 from uuid import uuid4
-from fasthtml.common import Div, Script
 
+from fasthtml.common import Div, Script
 
 altair_headers = [
     Script(src="https://cdn.jsdelivr.net/npm/vega@5"),
     Script(src="https://cdn.jsdelivr.net/npm/vega-lite@5"),
-    Script(src="https://cdn.jsdelivr.net/npm/vega-embed@6")
+    Script(src="https://cdn.jsdelivr.net/npm/vega-embed@6"),
 ]
 
 
 def altair2fasthml(chart):
     """This is the version with bad spelling"""
-    print("You have imported `altair2fasthml` which is a misspelled function. Sorry about that! It will be deprecated in favour of `altair2fasthtml` in a later release.")
+    print(
+        "You have imported `altair2fasthml` which is a misspelled function. Sorry about that! It will be deprecated in favour of `altair2fasthtml` in a later release."
+    )
     return altair2fasthtml(chart)
 
 

--- a/fh_altair/__init__.py
+++ b/fh_altair/__init__.py
@@ -1,12 +1,22 @@
 import json
 from uuid import uuid4
 
-from fasthtml.common import Div, Script
+from fasthtml.common import Div, Script, Style
 
 altair_headers = [
     Script(src="https://cdn.jsdelivr.net/npm/vega@5"),
     Script(src="https://cdn.jsdelivr.net/npm/vega-lite@5"),
     Script(src="https://cdn.jsdelivr.net/npm/vega-embed@6"),
+    Style("""
+    .vega-embed {
+      width: 100%;
+      display: flex;
+    }
+    .vega-embed details,
+    .vega-embed details summary {
+      position: relative;
+    }
+    """),
 ]
 
 
@@ -18,7 +28,7 @@ def altair2fasthml(chart):
     return altair2fasthtml(chart)
 
 
-def altair2fasthtml(chart, vega_options={"actions": False}):
+def altair2fasthtml(chart, vega_options={"actions": False}, full_width=False):
     """Convert an Altair chart to a FastHTML FT component
 
     Parameters
@@ -28,6 +38,8 @@ def altair2fasthtml(chart, vega_options={"actions": False}):
     vega_options : dict, optional
         Options dictionary passed to the vegaEmbed function, by default {"actions": False}
         which hides the Vega action menu.
+    full_width: bool, optional
+        When enabled, property width="responsive" is added to the chart allowing it to take up full width of parent Div
 
     Returns
     -------
@@ -35,6 +47,8 @@ def altair2fasthtml(chart, vega_options={"actions": False}):
         A FastHTML FT component containing both the target div and embedding script
 
     """
+    if full_width:
+        chart = chart.properties(width="container")
     jsonstr = chart.to_json()
     chart_id = f"uniq-{uuid4()}"
     return Div(

--- a/fh_altair/__init__.py
+++ b/fh_altair/__init__.py
@@ -1,3 +1,4 @@
+import json
 from uuid import uuid4
 
 from fasthtml.common import Div, Script
@@ -17,8 +18,10 @@ def altair2fasthml(chart):
     return altair2fasthtml(chart)
 
 
-def altair2fasthtml(chart):
+def altair2fasthtml(chart, vega_options={"actions": False}):
     jsonstr = chart.to_json()
-    chart_id = f'uniq-{uuid4()}'
-    settings = "{actions: false}"
-    return Div(Script(f"vegaEmbed('#{chart_id}', {jsonstr}, {settings});"), id=chart_id)
+    chart_id = f"uniq-{uuid4()}"
+    return Div(
+        Script(f"vegaEmbed('#{chart_id}', {jsonstr}, {json.dumps(vega_options)});"),
+        id=chart_id,
+    )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -13,3 +13,17 @@ def test_no_err():
         .properties(width=400, height=200)
     )
     return altair2fasthtml(chart)
+
+
+def test_vega_options_passed_to_vegaEmbed():
+    pltr = pd.DataFrame({"y": [1, 2, 3, 2], "x": [3, 1, 2, 4]})
+    chart = (
+        alt.Chart(pltr)
+        .mark_line()
+        .encode(x="x", y="y")
+        .properties(width=400, height=200)
+    )
+    vega_embed_call = altair2fasthtml(
+        chart, vega_options={"renderer": "svg", "actions": True}
+    ).__str__()
+    assert '{"renderer": "svg", "actions": true}' in vega_embed_call

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -34,3 +34,11 @@ def test_vega_options(sample_chart, renderer, actions):
         )
     )
     assert f'"renderer": "{renderer}", "actions": {str(actions).lower()}' in result_xml
+
+
+@pytest.mark.parametrize(
+    "full_width,expected", [(True, '"width": "container"'), (False, '"width": 400')]
+)
+def test_full_width(sample_chart, full_width, expected):
+    result_xml = to_xml(altair2fasthtml(sample_chart, full_width=full_width))
+    assert expected in result_xml

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -27,7 +27,6 @@ def test_no_err(sample_chart):
     [("svg", True), ("svg", False), ("canvas", True), ("canvas", False)],
 )
 def test_vega_options(sample_chart, renderer, actions):
-    vega_embed_call = to_xml(
     result_xml = to_xml(
         altair2fasthtml(
             sample_chart, vega_options={"renderer": renderer, "actions": actions}
@@ -37,7 +36,8 @@ def test_vega_options(sample_chart, renderer, actions):
 
 
 @pytest.mark.parametrize(
-    "full_width,expected", [(True, '"width": "container"'), (False, '"width": 400')]
+    "full_width,expected",
+    [(True, '"width": "container"'), (False, '"width": 400'), (True, '"height": 200')],
 )
 def test_full_width(sample_chart, full_width, expected):
     result_xml = to_xml(altair2fasthtml(sample_chart, full_width=full_width))

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,11 +1,13 @@
 import altair as alt
 import pandas as pd
+import pytest
 from fasthtml.common import to_xml
 
 from fh_altair import altair2fasthtml
 
 
-def test_no_err():
+@pytest.fixture
+def sample_chart():
     pltr = pd.DataFrame({"y": [1, 2, 3, 2], "x": [3, 1, 2, 4]})
     chart = (
         alt.Chart(pltr)
@@ -13,18 +15,15 @@ def test_no_err():
         .encode(x="x", y="y")
         .properties(width=400, height=200)
     )
-    return altair2fasthtml(chart)
+    return chart
 
 
-def test_vega_options_passed_to_vegaEmbed():
-    pltr = pd.DataFrame({"y": [1, 2, 3, 2], "x": [3, 1, 2, 4]})
-    chart = (
-        alt.Chart(pltr)
-        .mark_line()
-        .encode(x="x", y="y")
-        .properties(width=400, height=200)
-    )
+def test_no_err(sample_chart):
+    return altair2fasthtml(sample_chart)
+
+
+def test_vega_options_passed_to_vegaEmbed(sample_chart):
     vega_embed_call = to_xml(
-        altair2fasthtml(chart, vega_options={"renderer": "svg", "actions": True})
+        altair2fasthtml(sample_chart, vega_options={"renderer": "svg", "actions": True})
     )
     assert '{"renderer": "svg", "actions": true}' in vega_embed_call

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -28,11 +28,9 @@ def test_no_err(sample_chart):
 )
 def test_vega_options(sample_chart, renderer, actions):
     vega_embed_call = to_xml(
+    result_xml = to_xml(
         altair2fasthtml(
             sample_chart, vega_options={"renderer": renderer, "actions": actions}
         )
     )
-    assert (
-        f'"renderer": "{renderer}", "actions": {str(actions).lower()}'
-        in vega_embed_call
-    )
+    assert f'"renderer": "{renderer}", "actions": {str(actions).lower()}' in result_xml

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,8 +1,15 @@
-import pandas as pd
 import altair as alt
+import pandas as pd
+
 from fh_altair import altair2fasthtml
 
+
 def test_no_err():
-    pltr = pd.DataFrame({'y': [1, 2, 3, 2], 'x': [3, 1, 2, 4]})
-    chart = alt.Chart(pltr).mark_line().encode(x='x', y='y').properties(width=400, height=200)
+    pltr = pd.DataFrame({"y": [1, 2, 3, 2], "x": [3, 1, 2, 4]})
+    chart = (
+        alt.Chart(pltr)
+        .mark_line()
+        .encode(x="x", y="y")
+        .properties(width=400, height=200)
+    )
     return altair2fasthtml(chart)

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -22,8 +22,17 @@ def test_no_err(sample_chart):
     return altair2fasthtml(sample_chart)
 
 
-def test_vega_options_passed_to_vegaEmbed(sample_chart):
+@pytest.mark.parametrize(
+    "renderer,actions",
+    [("svg", True), ("svg", False), ("canvas", True), ("canvas", False)],
+)
+def test_vega_options(sample_chart, renderer, actions):
     vega_embed_call = to_xml(
-        altair2fasthtml(sample_chart, vega_options={"renderer": "svg", "actions": True})
+        altair2fasthtml(
+            sample_chart, vega_options={"renderer": renderer, "actions": actions}
+        )
     )
-    assert '{"renderer": "svg", "actions": true}' in vega_embed_call
+    assert (
+        f'"renderer": "{renderer}", "actions": {str(actions).lower()}'
+        in vega_embed_call
+    )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,5 +1,6 @@
 import altair as alt
 import pandas as pd
+from fasthtml.common import to_xml
 
 from fh_altair import altair2fasthtml
 
@@ -23,7 +24,7 @@ def test_vega_options_passed_to_vegaEmbed():
         .encode(x="x", y="y")
         .properties(width=400, height=200)
     )
-    vega_embed_call = altair2fasthtml(
-        chart, vega_options={"renderer": "svg", "actions": True}
-    ).__str__()
+    vega_embed_call = to_xml(
+        altair2fasthtml(chart, vega_options={"renderer": "svg", "actions": True})
+    )
     assert '{"renderer": "svg", "actions": true}' in vega_embed_call


### PR DESCRIPTION
https://github.com/koaning/fh-altair/issues/9

This PR adds the `full_width` parameter to `altair2fasthtml` and custom CSS for responsive charts.

The `full_width` parameter is optional, and defaults to False. When set to True, the resulting chart will take up the full width of its parent container.